### PR TITLE
add custom s3 endpoint option

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,5 +1,5 @@
 import { exec } from "child_process";
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { PutObjectCommand, S3Client, S3ClientConfig } from "@aws-sdk/client-s3";
 import { createReadStream } from "fs";
 
 import { env } from "./env";
@@ -9,7 +9,16 @@ const uploadToS3 = async ({ name, path }: {name: string, path: string}) => {
 
   const bucket = env.AWS_S3_BUCKET;
 
-  const client = new S3Client({ region: env.AWS_S3_REGION });
+  const clientOptions: S3ClientConfig = {
+    region: env.AWS_S3_REGION,
+  }
+
+  if (env.AWS_S3_ENDPOINT) {
+    console.log(`Using custom endpoint: ${env.AWS_S3_ENDPOINT}`)
+    clientOptions['endpoint'] = env.AWS_S3_ENDPOINT;
+  }
+
+  const client = new S3Client(clientOptions);
 
   await client.send(
     new PutObjectCommand({

--- a/src/env.ts
+++ b/src/env.ts
@@ -12,5 +12,10 @@ export const env = envsafe({
     desc: 'The cron schedule to run the backup on.',
     default: '0 5 * * *',
     allowEmpty: true
-  })
+  }),
+  AWS_S3_ENDPOINT: str({
+    desc: 'The S3 custom endpoint you want to use.',
+    default: '',
+    allowEmpty: true,
+  }),
 })


### PR DESCRIPTION
Add the ability to use a custom S3 endpoint.

### Why

In my case I don't use AWS services but I'm using a compatible S3 service (wasabi):

![image](https://user-images.githubusercontent.com/9168097/188199282-9b385c9e-2cd7-4b68-b745-75230ac6edc1.png)

Figured it can be useful for others in the same situation as me.

Thanks for this template!