### PR TITLE
Allow to set a base path for the file upload on S3

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -5,6 +5,11 @@ export const env = envsafe({
   AWS_SECRET_ACCESS_KEY: str(),
   AWS_S3_BUCKET: str(),
   AWS_S3_REGION: str(),
+  AWS_S3_BUCKET_BASE_PATH: str({
+    desc: 'Base path for the backup files',
+    default: '',
+    allowEmpty: true
+  }),
   BACKUP_DATABASE_URL: str({
     desc: 'The connection string of the database to backup.'
   }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { env } from "./env";
 
 const job = new CronJob(env.BACKUP_CRON_SCHEDULE, async () => {
   try {
-    await backup();
+    await backup(env.AWS_S3_BUCKET_BASE_PATH);
   } catch (error) {
     console.error("Error while running backup: ", error)
   }


### PR DESCRIPTION
Currently, the script uploads to the base path with a standard name format and it would be nice to have a way to customize that by defining a base path in order to separate files.
This can be useful when sharing the bucket over multiple projects that leverage this plugin.

To use it, just set the env like so `AWS_S3_BUCKET_BASE_PATH='my-project-1/db-backups'`, and the uploaded file will be created inside the folders.