### PR TITLE
Make it possible to run a backup on startup of the application

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,4 @@
-import { envsafe, str } from "envsafe";
+import { envsafe, str, bool } from "envsafe";
 
 export const env = envsafe({
   AWS_ACCESS_KEY_ID: str(),
@@ -18,4 +18,9 @@ export const env = envsafe({
     default: '',
     allowEmpty: true,
   }),
+  RUN_ON_STARTUP: bool({
+    desc: 'Run a backup on startup of this application',
+    default: false,
+    allowEmpty: true,
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,21 @@ import { CronJob } from "cron";
 import { backup } from "./backup";
 import { env } from "./env";
 
-const job = new CronJob(env.BACKUP_CRON_SCHEDULE, async () => {
+const tryBackup = async () => {
   try {
     await backup();
   } catch (error) {
     console.error("Error while running backup: ", error)
   }
+}
+
+const job = new CronJob(env.BACKUP_CRON_SCHEDULE, async () => {
+  await tryBackup();
 });
 
+if(env.RUN_ON_STARTUP) {
+  tryBackup();
+}
 job.start();
 
 console.log("Backup cron scheduled...")


### PR DESCRIPTION
This small PR makes it possible to run a backup on application startup

- Very handy to test if your AWS access is set up correctly before the CRON runs _(to me it happened, that it failed, without me noticing right away, because I set it in the middle of the night)_
- When you have some important data you want to backup, regardless of the CRON schedule, you can restart your app