### PR TITLE
Fix Compatibility with Postgres 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
-FROM alpine:3.14 AS build
+FROM alpine:3.18 AS build
 
 WORKDIR /root
 
 RUN apk add --update --no-cache nodejs npm
 
-COPY package*.json ./
-COPY tsconfig.json ./
+COPY package*.json tsconfig.json ./
 COPY src ./src
 
-RUN npm install
-RUN npm run build
-RUN npm prune --production
+RUN npm install && \
+    npm run build && \
+    npm prune --production
 
-FROM alpine:3.14
+FROM alpine:3.18
 
 WORKDIR /root
 
 COPY --from=build /root/node_modules ./node_modules
 COPY --from=build /root/dist ./dist
 
-RUN apk add --update --no-cache postgresql-client nodejs npm
+ARG PG_VERSION='16'
 
-ENTRYPOINT ["node", "dist/index.js"]
+RUN apk add --update --no-cache postgresql${PG_VERSION}-client --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main && \
+    apk add --update --no-cache nodejs npm
+
+CMD pg_isready --dbname=$BACKUP_DATABASE_URL && \
+    pg_dump --version && \
+    node dist/index.js

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.162.0",
     "cron": "^2.1.0",
-    "envsafe": "^2.0.3"
+    "envsafe": "^2.0.3",
+    "filesize": "^10.1.0"
   },
   "keywords": []
 }

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,6 +1,7 @@
 import { exec } from "child_process";
 import { PutObjectCommand, S3Client, S3ClientConfig } from "@aws-sdk/client-s3";
-import { createReadStream, unlink } from "fs";
+import { createReadStream, unlink, statSync } from "fs";
+import { filesize } from "filesize";
 import path from "path";
 import os from "os";
 
@@ -47,6 +48,8 @@ const dumpToFile = async (path: string) => {
         reject({ stderr: stderr.trimEnd() });
         return;
       }
+
+      console.log("Backup size:", filesize(statSync(path).size));
 
       resolve(undefined);
     });

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,16 +1,18 @@
 import { exec } from "child_process";
 import { PutObjectCommand, S3Client, S3ClientConfig } from "@aws-sdk/client-s3";
 import { createReadStream, unlink } from "fs";
+import path from "path";
+import os from "os";
 
 import { env } from "./env";
 
-const uploadToS3 = async ({ name, path }: {name: string, path: string}) => {
+const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
   console.log("Uploading backup to S3...");
 
   const bucket = env.AWS_S3_BUCKET;
 
   const clientOptions: S3ClientConfig = {
-    region: env.AWS_S3_REGION,
+    region: env.AWS_S3_REGION
   }
 
   if (env.AWS_S3_ENDPOINT) {
@@ -26,7 +28,7 @@ const uploadToS3 = async ({ name, path }: {name: string, path: string}) => {
       Key: name,
       Body: createReadStream(path),
     })
-  )
+  );
 
   console.log("Backup uploaded to S3...");
 }
@@ -35,17 +37,20 @@ const dumpToFile = async (path: string) => {
   console.log("Dumping DB to file...");
 
   await new Promise((resolve, reject) => {
-    exec(
-      `pg_dump ${env.BACKUP_DATABASE_URL} -F t | gzip > ${path}`,
-      (error, stdout, stderr) => {
-        if (error) {
-          reject({ error: JSON.stringify(error), stderr });
-          return;
-        }
-
-        resolve(undefined);
+    exec(`pg_dump --dbname=${env.BACKUP_DATABASE_URL} --format=tar | gzip > ${path}`, (error, stdout, stderr) => {
+      if (error) {
+        reject({ error: error, stderr: stderr.trimEnd() });
+        return;
       }
-    );
+
+      if (stderr != "") {
+        reject({ stderr: stderr.trimEnd() });
+        return;
+      }
+
+      resolve(undefined);
+    });
+
   });
 
   console.log("DB dumped to file...");
@@ -55,24 +60,24 @@ const deleteFile = async (path: string) => {
   console.log("Deleting file...");
   await new Promise((resolve, reject) => {
     unlink(path, (err) => {
-      reject({ error: JSON.stringify(err) });
+      reject({ error: err });
       return;
     });
     resolve(undefined);
-  })
+  });
 }
 
 export const backup = async () => {
-  console.log("Initiating DB backup...")
+  console.log("Initiating DB backup...");
 
-  let date = new Date().toISOString()
-  const timestamp = date.replace(/[:.]+/g, '-')
-  const filename = `backup-${timestamp}.tar.gz`
-  const filepath = `/tmp/${filename}`
+  let date = new Date().toISOString();
+  const timestamp = date.replace(/[:.]+/g, '-');
+  const filename = `backup-${timestamp}.tar.gz`;
+  const filepath = path.join(os.tmpdir(), filename);
 
-  await dumpToFile(filepath)
-  await uploadToS3({name: filename, path: filepath})
-  await deleteFile(filepath)
+  await dumpToFile(filepath);
+  await uploadToS3({ name: filename, path: filepath });
+  await deleteFile(filepath);
 
-  console.log("DB backup complete...")
+  console.log("DB backup complete...");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,13 @@ import { CronJob } from "cron";
 import { backup } from "./backup";
 import { env } from "./env";
 
+console.log("NodeJS Version: " + process.version);
+
 const tryBackup = async () => {
   try {
     await backup();
   } catch (error) {
-    console.error("Error while running backup: ", error)
+    console.error("Error while running backup: ", error);
   }
 }
 
@@ -18,6 +20,7 @@ const job = new CronJob(env.BACKUP_CRON_SCHEDULE, async () => {
 if(env.RUN_ON_STARTUP) {
   tryBackup();
 }
+
 job.start();
 
-console.log("Backup cron scheduled...")
+console.log("Backup cron scheduled...");

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,6 +935,11 @@ fast-xml-parser@3.19.0:
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
   integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
 
+filesize@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-10.1.0.tgz#846f5cd8d16e073c5d6767651a8264f6149183cd"
+  integrity sha512-GTLKYyBSDz3nPhlLVPjPWZCnhkd9TrrRArNcy8Z+J2cqScB7h2McAzR6NBX6nYOoWafql0roY8hrocxnZBv9CQ==
+
 luxon@^1.23.x:
   version "1.28.0"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.0.tgz#e7f96daad3938c06a62de0fb027115d251251fbf"


### PR DESCRIPTION
The Dockerfile was installing pg_dump version 14, this version is incompatible with the Postgres databases currently being deployed. pg_dump 16 will now be installed by default with support for a `PG_VERSION` service variable to change the version installed.
(though pg_dump 16 can dump Postgres 14 databases)

Additionally, the errors that pg_dump was printing about the version miss-match weren't being caught, resulting in 20-byte tarballs ending up in the S3 bucket, while everything looked good in the deployment logs, this fixes that too.

It also cleans up various things :)