### PR TITLE
Added features, single shot mode and optional subfolder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=build /app/dist ./dist
 
 ARG PG_VERSION='16'
 
-RUN apk add --update --no-cache postgresql${PG_VERSION}-client --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --update --no-cache postgresql${PG_VERSION}-client
 
 CMD pg_isready --dbname=$BACKUP_DATABASE_URL && \
     pg_dump --version && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /app
 
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./
 
 ARG PG_VERSION='16'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,22 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.529.1",
-        "@aws-sdk/lib-storage": "^3.529.1",
+        "@aws-sdk/client-s3": "^3.549.0",
+        "@aws-sdk/lib-storage": "^3.549.0",
         "cron": "^3.1.6",
         "envsafe": "^2.0.3",
-        "filesize": "^10.1.0"
+        "filesize": "^10.1.1"
       },
       "devDependencies": {
         "@types/cron": "^2.0.1",
-        "@types/node": "^20.11.25",
-        "typescript": "^5.4.2"
+        "@types/node": "^20.12.4",
+        "typescript": "^5.4.4"
       }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -32,11 +33,13 @@
     },
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/crc32c": {
       "version": "3.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -45,7 +48,8 @@
     },
     "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
@@ -77,7 +81,8 @@
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -91,11 +96,13 @@
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -104,7 +111,8 @@
     },
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
@@ -131,362 +139,375 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.549.0.tgz",
+      "integrity": "sha512-mogi9u0blkrpol2RPuc3iO73jRhL43/iT5TR80zm3QR+i+tRxAuH2cxvyDvIxkRua296aZ9VNxwg47tM5xsHRQ==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.529.1",
-        "@aws-sdk/core": "3.529.1",
-        "@aws-sdk/credential-provider-node": "3.529.1",
-        "@aws-sdk/middleware-bucket-endpoint": "3.525.0",
-        "@aws-sdk/middleware-expect-continue": "3.523.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.523.0",
-        "@aws-sdk/middleware-host-header": "3.523.0",
-        "@aws-sdk/middleware-location-constraint": "3.523.0",
-        "@aws-sdk/middleware-logger": "3.523.0",
-        "@aws-sdk/middleware-recursion-detection": "3.523.0",
-        "@aws-sdk/middleware-sdk-s3": "3.525.0",
-        "@aws-sdk/middleware-signing": "3.523.0",
-        "@aws-sdk/middleware-ssec": "3.523.0",
-        "@aws-sdk/middleware-user-agent": "3.525.0",
-        "@aws-sdk/region-config-resolver": "3.525.0",
-        "@aws-sdk/signature-v4-multi-region": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@aws-sdk/util-user-agent-browser": "3.523.0",
-        "@aws-sdk/util-user-agent-node": "3.525.0",
-        "@aws-sdk/xml-builder": "3.523.0",
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/core": "^1.3.5",
-        "@smithy/eventstream-serde-browser": "^2.1.3",
-        "@smithy/eventstream-serde-config-resolver": "^2.1.3",
-        "@smithy/eventstream-serde-node": "^2.1.3",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/hash-blob-browser": "^2.1.3",
-        "@smithy/hash-node": "^2.1.3",
-        "@smithy/hash-stream-node": "^2.1.3",
-        "@smithy/invalid-dependency": "^2.1.3",
-        "@smithy/md5-js": "^2.1.3",
-        "@smithy/middleware-content-length": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.4",
-        "@smithy/util-defaults-mode-node": "^2.2.3",
-        "@smithy/util-endpoints": "^1.1.4",
-        "@smithy/util-retry": "^2.1.3",
-        "@smithy/util-stream": "^2.1.3",
-        "@smithy/util-utf8": "^2.1.1",
-        "@smithy/util-waiter": "^2.1.3",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/credential-provider-node": "3.549.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.535.0",
+        "@aws-sdk/middleware-expect-continue": "3.535.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-location-constraint": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-sdk-s3": "3.535.0",
+        "@aws-sdk/middleware-signing": "3.535.0",
+        "@aws-sdk/middleware-ssec": "3.537.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/signature-v4-multi-region": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@aws-sdk/xml-builder": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/eventstream-serde-browser": "^2.2.0",
+        "@smithy/eventstream-serde-config-resolver": "^2.2.0",
+        "@smithy/eventstream-serde-node": "^2.2.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-blob-browser": "^2.2.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/hash-stream-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/md5-js": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-stream": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "@smithy/util-waiter": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.549.0.tgz",
+      "integrity": "sha512-lz+yflOAj5Q263FlCsKpNqttaCb2NPh8jC76gVCqCt7TPxRDBYVaqg0OZYluDaETIDNJi4DwN2Azcck7ilwuPw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.529.1",
-        "@aws-sdk/middleware-host-header": "3.523.0",
-        "@aws-sdk/middleware-logger": "3.523.0",
-        "@aws-sdk/middleware-recursion-detection": "3.523.0",
-        "@aws-sdk/middleware-user-agent": "3.525.0",
-        "@aws-sdk/region-config-resolver": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@aws-sdk/util-user-agent-browser": "3.523.0",
-        "@aws-sdk/util-user-agent-node": "3.525.0",
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/core": "^1.3.5",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/hash-node": "^2.1.3",
-        "@smithy/invalid-dependency": "^2.1.3",
-        "@smithy/middleware-content-length": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.4",
-        "@smithy/util-defaults-mode-node": "^2.2.3",
-        "@smithy/util-endpoints": "^1.1.4",
-        "@smithy/util-middleware": "^2.1.3",
-        "@smithy/util-retry": "^2.1.3",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.549.0.tgz",
+      "integrity": "sha512-FbB4A78ILAb8sM4TfBd+3CrQcfZIhe0gtVZNbaxpq5cJZh1K7oZ8vPfKw4do9JWkDUXPLsD9Bwz12f8/JpAb6Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.529.1",
-        "@aws-sdk/core": "3.529.1",
-        "@aws-sdk/middleware-host-header": "3.523.0",
-        "@aws-sdk/middleware-logger": "3.523.0",
-        "@aws-sdk/middleware-recursion-detection": "3.523.0",
-        "@aws-sdk/middleware-user-agent": "3.525.0",
-        "@aws-sdk/region-config-resolver": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@aws-sdk/util-user-agent-browser": "3.523.0",
-        "@aws-sdk/util-user-agent-node": "3.525.0",
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/core": "^1.3.5",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/hash-node": "^2.1.3",
-        "@smithy/invalid-dependency": "^2.1.3",
-        "@smithy/middleware-content-length": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.4",
-        "@smithy/util-defaults-mode-node": "^2.2.3",
-        "@smithy/util-endpoints": "^1.1.4",
-        "@smithy/util-middleware": "^2.1.3",
-        "@smithy/util-retry": "^2.1.3",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-provider-node": "^3.529.1"
+        "@aws-sdk/credential-provider-node": "^3.549.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.549.0.tgz",
+      "integrity": "sha512-63IreJ598Dzvpb+6sy81KfIX5iQxnrWSEtlyeCdC2GO6gmSQVwJzc9kr5pAC83lHmlZcm/Q3KZr3XBhRQqP0og==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.529.1",
-        "@aws-sdk/middleware-host-header": "3.523.0",
-        "@aws-sdk/middleware-logger": "3.523.0",
-        "@aws-sdk/middleware-recursion-detection": "3.523.0",
-        "@aws-sdk/middleware-user-agent": "3.525.0",
-        "@aws-sdk/region-config-resolver": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@aws-sdk/util-user-agent-browser": "3.523.0",
-        "@aws-sdk/util-user-agent-node": "3.525.0",
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/core": "^1.3.5",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/hash-node": "^2.1.3",
-        "@smithy/invalid-dependency": "^2.1.3",
-        "@smithy/middleware-content-length": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.4",
-        "@smithy/util-defaults-mode-node": "^2.2.3",
-        "@smithy/util-endpoints": "^1.1.4",
-        "@smithy/util-middleware": "^2.1.3",
-        "@smithy/util-retry": "^2.1.3",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-provider-node": "^3.529.1"
+        "@aws-sdk/credential-provider-node": "^3.549.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.549.0.tgz",
+      "integrity": "sha512-jC61OxJn72r/BbuDRCcluiw05Xw9eVLG0CwxQpF3RocxfxyZqlrGYaGecZ8Wy+7g/3sqGRC/Ar5eUhU1YcLx7w==",
       "dependencies": {
-        "@smithy/core": "^1.3.5",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/signature-v4": "^2.1.3",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
+        "@smithy/core": "^1.4.1",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
         "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
+      "integrity": "sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.525.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.535.0.tgz",
+      "integrity": "sha512-kdj1wCmOMZ29jSlUskRqN04S6fJ4dvt0Nq9Z32SA6wO7UG8ht6Ot9h/au/eTWJM3E1somZ7D771oK7dQt9b8yw==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-stream": "^2.1.3",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.549.0.tgz",
+      "integrity": "sha512-k6IIrluZjQpzui5Din8fW3bFFhHaJ64XrsfYx0Ks1mb7xan84dJxmYP3tdDDmLzUeJv5h95ag88taHfjY9rakA==",
       "dependencies": {
-        "@aws-sdk/client-sts": "3.529.1",
-        "@aws-sdk/credential-provider-env": "3.523.0",
-        "@aws-sdk/credential-provider-process": "3.523.0",
-        "@aws-sdk/credential-provider-sso": "3.529.1",
-        "@aws-sdk/credential-provider-web-identity": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/credential-provider-imds": "^2.2.3",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.549.0",
+        "@aws-sdk/credential-provider-web-identity": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.549.0.tgz",
+      "integrity": "sha512-f3YgalsMuywEAVX4AUm9tojqrBdfpAac0+D320ePzas0Ntbp7ItYu9ceKIhgfzXO3No7P3QK0rCrOxL+ABTn8Q==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.523.0",
-        "@aws-sdk/credential-provider-http": "3.525.0",
-        "@aws-sdk/credential-provider-ini": "3.529.1",
-        "@aws-sdk/credential-provider-process": "3.523.0",
-        "@aws-sdk/credential-provider-sso": "3.529.1",
-        "@aws-sdk/credential-provider-web-identity": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/credential-provider-imds": "^2.2.3",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-http": "3.535.0",
+        "@aws-sdk/credential-provider-ini": "3.549.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.549.0",
+        "@aws-sdk/credential-provider-web-identity": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.535.0.tgz",
+      "integrity": "sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.549.0.tgz",
+      "integrity": "sha512-BGopRKHs7W8zkoH8qmSHrjudj263kXbhVkAUPxVUz0I28+CZNBgJC/RfVCbOpzmysIQEpwSqvOv1y0k+DQzIJQ==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.529.1",
-        "@aws-sdk/token-providers": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.549.0",
+        "@aws-sdk/token-providers": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.549.0.tgz",
+      "integrity": "sha512-QzclVXPxuwSI7515l34sdvliVq5leroO8P7RQFKRgfyQKO45o1psghierwG3PgV6jlMiv78FIAGJBr/n4qZ7YA==",
       "dependencies": {
-        "@aws-sdk/client-sts": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.549.0.tgz",
+      "integrity": "sha512-I4MBQQVPFLBNXmyX3bpwuSNxYxV3a4YXoulLpY7F39E7/EjF+AHPppBHJ4Z8pvoaTi/fSKtBc0EEEr5MN/gfZA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/smithy-client": "^2.5.0",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -496,235 +517,252 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.525.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.535.0.tgz",
+      "integrity": "sha512-7sijlfQsc4UO9Fsl11mU26Y5f9E7g6UoNg/iJUBpC5pgvvmdBRO5UEhbB/gnqvOEPsBXyhmfzbstebq23Qdz7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-arn-parser": "3.495.0",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-arn-parser": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.535.0.tgz",
+      "integrity": "sha512-hFKyqUBky0NWCVku8iZ9+PACehx0p6vuMw5YnZf8FVgHP0fode0b/NwQY6UY7oor/GftvRsAlRUAWGNFEGUpwA==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.535.0.tgz",
+      "integrity": "sha512-rBIzldY9jjRATxICDX7t77aW6ctqmVDgnuAOgbVT5xgHftt4o7PGWKoMvl/45hYqoQgxVFnCBof9bxkqSBebVA==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/is-array-buffer": "^2.1.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.535.0.tgz",
+      "integrity": "sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.535.0.tgz",
+      "integrity": "sha512-SxfS9wfidUZZ+WnlKRTCRn3h+XTsymXRXPJj8VV6hNRNeOwzNweoG3YhQbTowuuNfXf89m9v6meYkBBtkdacKw==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.535.0.tgz",
+      "integrity": "sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.535.0.tgz",
+      "integrity": "sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.525.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.535.0.tgz",
+      "integrity": "sha512-/dLG/E3af6ohxkQ5GBHT8tZfuPIg6eItKxCXuulvYj0Tqgf3Mb+xTsvSkxQsJF06RS4sH7Qsg/PnB8ZfrJrXpg==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-arn-parser": "3.495.0",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/signature-v4": "^2.1.3",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-arn-parser": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.535.0.tgz",
+      "integrity": "sha512-Rb4sfus1Gc5paRl9JJgymJGsb/i3gJKK/rTuFZICdd1PBBE5osIOHP5CpzWYBtc5LlyZE1a2QoxPMCyG+QUGPw==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/signature-v4": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-middleware": "^2.1.3",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.537.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.537.0.tgz",
+      "integrity": "sha512-2QWMrbwd5eBy5KCYn9a15JEWBgrK2qFEKQN2lqb/6z0bhtevIOxIRfC99tzvRuPt6nixFQ+ynKuBjcfT4ZFrdQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.525.0",
-      "license": "Apache-2.0",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.540.0.tgz",
+      "integrity": "sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.525.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.535.0.tgz",
+      "integrity": "sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "@smithy/util-middleware": "^2.1.3",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.525.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.535.0.tgz",
+      "integrity": "sha512-tqCsEsEj8icW0SAh3NvyhRUq54Gz2pu4NM2tOSrFp7SO55heUUaRLSzYteNZCTOupH//AAaZvbN/UUTO/DrOog==",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/signature-v4": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-sdk-s3": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.529.1",
-      "license": "Apache-2.0",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.549.0.tgz",
+      "integrity": "sha512-rJyeXkXknLukRFGuMQOgKnPBa+kLODJtOqEBf929SpQ96f1I6ytdndmWbB5B/OQN5Fu5DOOQUQqJypDQVl5ibQ==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso-oidc": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.495.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.535.0.tgz",
+      "integrity": "sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.525.0",
-      "license": "Apache-2.0",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.540.0.tgz",
+      "integrity": "sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-endpoints": "^1.1.4",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -745,23 +783,25 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.535.0.tgz",
+      "integrity": "sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.525.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.535.0.tgz",
+      "integrity": "sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -787,599 +827,649 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.523.0",
-      "license": "Apache-2.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.535.0.tgz",
+      "integrity": "sha512-VXAq/Jz8KIrU84+HqsOJhIKZqG0PNTdi6n6PFQ4xJf44ZQHD/5C7ouH4qCFX5XgZXcgbRIcMVVYGC6Jye0dRng==",
       "dependencies": {
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "2.1.1",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.2.0.tgz",
+      "integrity": "sha512-3GJNvRwXBGdkDZZOGiziVYzDpn4j6zfyULHMDKAGIUo72yHALpE9CbhfQp/XcLNVoc1byfMpn6uW5H2BqPjgaQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "2.1.2",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.2.0.tgz",
+      "integrity": "sha512-VNB5+1oCgX3Fzs072yuRsUoC2N4Zg/LJ11DTxX3+Qu+Paa6AmbIF0E9sc2wthz9Psrk/zcOlTCyuposlIhPjZQ==",
       "dependencies": {
-        "@smithy/util-base64": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.1.5",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+      "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-config-provider": "^2.2.1",
-        "@smithy/util-middleware": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "1.3.7",
-      "license": "Apache-2.0",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.4.6",
-        "@smithy/middleware-retry": "^2.1.6",
-        "@smithy/middleware-serde": "^2.2.1",
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/smithy-client": "^2.4.4",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-middleware": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.2.6",
-      "license": "Apache-2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+      "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/property-provider": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "@smithy/url-parser": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.2.0.tgz",
+      "integrity": "sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.2.0.tgz",
+      "integrity": "sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.4.4",
-      "license": "Apache-2.0",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/querystring-builder": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-base64": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.2.0.tgz",
+      "integrity": "sha512-SGPoVH8mdXBqrkVCJ1Hd1X7vh1zDXojNN1yZyZTZsCno99hVue9+IYzWDjq/EQDDXxmITB0gBmuyPh8oAZSTcg==",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^2.1.1",
-        "@smithy/chunked-blob-reader-native": "^2.1.2",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/chunked-blob-reader": "^2.2.0",
+        "@smithy/chunked-blob-reader-native": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+      "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.2.0.tgz",
+      "integrity": "sha512-aT+HCATOSRMGpPI7bi7NSsTNVZE/La9IaxLXWoVAYMxHT5hGO3ZOGEMZQg8A6nNL+pdFGtZQtND1eoY084HgHQ==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+      "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.1.1",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.2.0.tgz",
+      "integrity": "sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+      "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.4.6",
-      "license": "Apache-2.0",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.2.1",
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/shared-ini-file-loader": "^2.3.5",
-        "@smithy/types": "^2.11.0",
-        "@smithy/url-parser": "^2.1.4",
-        "@smithy/util-middleware": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.1.6",
-      "license": "Apache-2.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+      "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/service-error-classification": "^2.1.4",
-        "@smithy/smithy-client": "^2.4.4",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-middleware": "^2.1.4",
-        "@smithy/util-retry": "^2.1.4",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.2.1",
-      "license": "Apache-2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.2.5",
-      "license": "Apache-2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.1.4",
-        "@smithy/shared-ini-file-loader": "^2.3.5",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.4.2",
-      "license": "Apache-2.0",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.1.4",
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/querystring-builder": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.2.2",
-      "license": "Apache-2.0",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-uri-escape": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+      "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
       "dependencies": {
-        "@smithy/types": "^2.11.0"
+        "@smithy/types": "^2.12.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.3.5",
-      "license": "Apache-2.0",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.2.1.tgz",
+      "integrity": "sha512-j5fHgL1iqKTsKJ1mTcw88p0RUcidDu95AWSeZTgiYJb+QcfwWU/UpBnaqiB59FNH5MiAZuSbOBnZlwzeeY2tIw==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.1.4",
-        "@smithy/is-array-buffer": "^2.1.1",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "@smithy/util-middleware": "^2.1.4",
-        "@smithy/util-uri-escape": "^2.1.1",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.4.4",
-      "license": "Apache-2.0",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.4.6",
-        "@smithy/middleware-stack": "^2.1.4",
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-stream": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.11.0",
-      "license": "Apache-2.0",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.2.0",
-      "license": "Apache-2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.1.1",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.2.1",
-      "license": "Apache-2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.1.1",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "2.2.1",
-      "license": "Apache-2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+      "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.1.6",
-      "license": "Apache-2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+      "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
       "dependencies": {
-        "@smithy/property-provider": "^2.1.4",
-        "@smithy/smithy-client": "^2.4.4",
-        "@smithy/types": "^2.11.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.2.6",
-      "license": "Apache-2.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+      "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.1.5",
-        "@smithy/credential-provider-imds": "^2.2.6",
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/property-provider": "^2.1.4",
-        "@smithy/smithy-client": "^2.4.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.1.5",
-      "license": "Apache-2.0",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
+      "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.1.1",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
       "dependencies": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+      "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.4.4",
-        "@smithy/node-http-handler": "^2.4.2",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-base64": "^2.2.0",
-        "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.1.1",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.2.0",
-      "license": "Apache-2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.2.0.tgz",
+      "integrity": "sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1399,9 +1489,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.11.25",
+      "version": "20.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.4.tgz",
+      "integrity": "sha512-E+Fa9z3wSQpzgYQdYmme5X3OTuejnnTx88A6p6vkkJosR3KBz+HpE3kqNm98VE6cfLFcISx7zW7MsJkH6KwbTw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1426,7 +1517,8 @@
     },
     "node_modules/bowser": {
       "version": "2.11.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/buffer": {
       "version": "5.6.0",
@@ -1460,6 +1552,8 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "funding": [
         {
           "type": "paypal",
@@ -1470,7 +1564,6 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -1479,8 +1572,9 @@
       }
     },
     "node_modules/filesize": {
-      "version": "10.1.0",
-      "license": "BSD-3-Clause",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.1.tgz",
+      "integrity": "sha512-L0cdwZrKlwZQkMSFnCflJ6J2Y+5egO/p3vgRSDQGxQt++QbUZe5gMbRO6kg6gzwQDPvq2Fk9AmoxUNfZ5gdqaQ==",
       "engines": {
         "node": ">= 10.4.0"
       }
@@ -1561,16 +1655,18 @@
     },
     "node_modules/strnum": {
       "version": "1.0.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/tslib": {
       "version": "2.6.2",
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.4.2",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1589,8 +1685,13 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -1599,6 +1700,8 @@
   "dependencies": {
     "@aws-crypto/crc32": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -1606,12 +1709,16 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/crc32c": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -1619,7 +1726,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -1653,6 +1762,8 @@
     },
     "@aws-crypto/sha256-browser": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "requires": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -1665,12 +1776,16 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/sha256-js": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -1678,7 +1793,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -1707,474 +1824,534 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.549.0.tgz",
+      "integrity": "sha512-mogi9u0blkrpol2RPuc3iO73jRhL43/iT5TR80zm3QR+i+tRxAuH2cxvyDvIxkRua296aZ9VNxwg47tM5xsHRQ==",
       "requires": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.529.1",
-        "@aws-sdk/core": "3.529.1",
-        "@aws-sdk/credential-provider-node": "3.529.1",
-        "@aws-sdk/middleware-bucket-endpoint": "3.525.0",
-        "@aws-sdk/middleware-expect-continue": "3.523.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.523.0",
-        "@aws-sdk/middleware-host-header": "3.523.0",
-        "@aws-sdk/middleware-location-constraint": "3.523.0",
-        "@aws-sdk/middleware-logger": "3.523.0",
-        "@aws-sdk/middleware-recursion-detection": "3.523.0",
-        "@aws-sdk/middleware-sdk-s3": "3.525.0",
-        "@aws-sdk/middleware-signing": "3.523.0",
-        "@aws-sdk/middleware-ssec": "3.523.0",
-        "@aws-sdk/middleware-user-agent": "3.525.0",
-        "@aws-sdk/region-config-resolver": "3.525.0",
-        "@aws-sdk/signature-v4-multi-region": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@aws-sdk/util-user-agent-browser": "3.523.0",
-        "@aws-sdk/util-user-agent-node": "3.525.0",
-        "@aws-sdk/xml-builder": "3.523.0",
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/core": "^1.3.5",
-        "@smithy/eventstream-serde-browser": "^2.1.3",
-        "@smithy/eventstream-serde-config-resolver": "^2.1.3",
-        "@smithy/eventstream-serde-node": "^2.1.3",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/hash-blob-browser": "^2.1.3",
-        "@smithy/hash-node": "^2.1.3",
-        "@smithy/hash-stream-node": "^2.1.3",
-        "@smithy/invalid-dependency": "^2.1.3",
-        "@smithy/md5-js": "^2.1.3",
-        "@smithy/middleware-content-length": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.4",
-        "@smithy/util-defaults-mode-node": "^2.2.3",
-        "@smithy/util-endpoints": "^1.1.4",
-        "@smithy/util-retry": "^2.1.3",
-        "@smithy/util-stream": "^2.1.3",
-        "@smithy/util-utf8": "^2.1.1",
-        "@smithy/util-waiter": "^2.1.3",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/credential-provider-node": "3.549.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.535.0",
+        "@aws-sdk/middleware-expect-continue": "3.535.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.535.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-location-constraint": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-sdk-s3": "3.535.0",
+        "@aws-sdk/middleware-signing": "3.535.0",
+        "@aws-sdk/middleware-ssec": "3.537.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/signature-v4-multi-region": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@aws-sdk/xml-builder": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/eventstream-serde-browser": "^2.2.0",
+        "@smithy/eventstream-serde-config-resolver": "^2.2.0",
+        "@smithy/eventstream-serde-node": "^2.2.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-blob-browser": "^2.2.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/hash-stream-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/md5-js": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-stream": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "@smithy/util-waiter": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.549.0.tgz",
+      "integrity": "sha512-lz+yflOAj5Q263FlCsKpNqttaCb2NPh8jC76gVCqCt7TPxRDBYVaqg0OZYluDaETIDNJi4DwN2Azcck7ilwuPw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.529.1",
-        "@aws-sdk/middleware-host-header": "3.523.0",
-        "@aws-sdk/middleware-logger": "3.523.0",
-        "@aws-sdk/middleware-recursion-detection": "3.523.0",
-        "@aws-sdk/middleware-user-agent": "3.525.0",
-        "@aws-sdk/region-config-resolver": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@aws-sdk/util-user-agent-browser": "3.523.0",
-        "@aws-sdk/util-user-agent-node": "3.525.0",
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/core": "^1.3.5",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/hash-node": "^2.1.3",
-        "@smithy/invalid-dependency": "^2.1.3",
-        "@smithy/middleware-content-length": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.4",
-        "@smithy/util-defaults-mode-node": "^2.2.3",
-        "@smithy/util-endpoints": "^1.1.4",
-        "@smithy/util-middleware": "^2.1.3",
-        "@smithy/util-retry": "^2.1.3",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.549.0.tgz",
+      "integrity": "sha512-FbB4A78ILAb8sM4TfBd+3CrQcfZIhe0gtVZNbaxpq5cJZh1K7oZ8vPfKw4do9JWkDUXPLsD9Bwz12f8/JpAb6Q==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.529.1",
-        "@aws-sdk/core": "3.529.1",
-        "@aws-sdk/middleware-host-header": "3.523.0",
-        "@aws-sdk/middleware-logger": "3.523.0",
-        "@aws-sdk/middleware-recursion-detection": "3.523.0",
-        "@aws-sdk/middleware-user-agent": "3.525.0",
-        "@aws-sdk/region-config-resolver": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@aws-sdk/util-user-agent-browser": "3.523.0",
-        "@aws-sdk/util-user-agent-node": "3.525.0",
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/core": "^1.3.5",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/hash-node": "^2.1.3",
-        "@smithy/invalid-dependency": "^2.1.3",
-        "@smithy/middleware-content-length": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.4",
-        "@smithy/util-defaults-mode-node": "^2.2.3",
-        "@smithy/util-endpoints": "^1.1.4",
-        "@smithy/util-middleware": "^2.1.3",
-        "@smithy/util-retry": "^2.1.3",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.549.0.tgz",
+      "integrity": "sha512-63IreJ598Dzvpb+6sy81KfIX5iQxnrWSEtlyeCdC2GO6gmSQVwJzc9kr5pAC83lHmlZcm/Q3KZr3XBhRQqP0og==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.529.1",
-        "@aws-sdk/middleware-host-header": "3.523.0",
-        "@aws-sdk/middleware-logger": "3.523.0",
-        "@aws-sdk/middleware-recursion-detection": "3.523.0",
-        "@aws-sdk/middleware-user-agent": "3.525.0",
-        "@aws-sdk/region-config-resolver": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@aws-sdk/util-user-agent-browser": "3.523.0",
-        "@aws-sdk/util-user-agent-node": "3.525.0",
-        "@smithy/config-resolver": "^2.1.4",
-        "@smithy/core": "^1.3.5",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/hash-node": "^2.1.3",
-        "@smithy/invalid-dependency": "^2.1.3",
-        "@smithy/middleware-content-length": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/middleware-retry": "^2.1.4",
-        "@smithy/middleware-serde": "^2.1.3",
-        "@smithy/middleware-stack": "^2.1.3",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/url-parser": "^2.1.3",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.4",
-        "@smithy/util-defaults-mode-node": "^2.2.3",
-        "@smithy/util-endpoints": "^1.1.4",
-        "@smithy/util-middleware": "^2.1.3",
-        "@smithy/util-retry": "^2.1.3",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.549.0",
+        "@aws-sdk/middleware-host-header": "3.535.0",
+        "@aws-sdk/middleware-logger": "3.535.0",
+        "@aws-sdk/middleware-recursion-detection": "3.535.0",
+        "@aws-sdk/middleware-user-agent": "3.540.0",
+        "@aws-sdk/region-config-resolver": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@aws-sdk/util-user-agent-browser": "3.535.0",
+        "@aws-sdk/util-user-agent-node": "3.535.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.1",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-retry": "^2.3.0",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.0",
+        "@smithy/util-defaults-mode-node": "^2.3.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/core": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.549.0.tgz",
+      "integrity": "sha512-jC61OxJn72r/BbuDRCcluiw05Xw9eVLG0CwxQpF3RocxfxyZqlrGYaGecZ8Wy+7g/3sqGRC/Ar5eUhU1YcLx7w==",
       "requires": {
-        "@smithy/core": "^1.3.5",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/signature-v4": "^2.1.3",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
+        "@smithy/core": "^1.4.1",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
         "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
+      "integrity": "sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-http": {
-      "version": "3.525.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.535.0.tgz",
+      "integrity": "sha512-kdj1wCmOMZ29jSlUskRqN04S6fJ4dvt0Nq9Z32SA6wO7UG8ht6Ot9h/au/eTWJM3E1somZ7D771oK7dQt9b8yw==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/fetch-http-handler": "^2.4.3",
-        "@smithy/node-http-handler": "^2.4.1",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-stream": "^2.1.3",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.549.0.tgz",
+      "integrity": "sha512-k6IIrluZjQpzui5Din8fW3bFFhHaJ64XrsfYx0Ks1mb7xan84dJxmYP3tdDDmLzUeJv5h95ag88taHfjY9rakA==",
       "requires": {
-        "@aws-sdk/client-sts": "3.529.1",
-        "@aws-sdk/credential-provider-env": "3.523.0",
-        "@aws-sdk/credential-provider-process": "3.523.0",
-        "@aws-sdk/credential-provider-sso": "3.529.1",
-        "@aws-sdk/credential-provider-web-identity": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/credential-provider-imds": "^2.2.3",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.549.0",
+        "@aws-sdk/credential-provider-web-identity": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.549.0.tgz",
+      "integrity": "sha512-f3YgalsMuywEAVX4AUm9tojqrBdfpAac0+D320ePzas0Ntbp7ItYu9ceKIhgfzXO3No7P3QK0rCrOxL+ABTn8Q==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.523.0",
-        "@aws-sdk/credential-provider-http": "3.525.0",
-        "@aws-sdk/credential-provider-ini": "3.529.1",
-        "@aws-sdk/credential-provider-process": "3.523.0",
-        "@aws-sdk/credential-provider-sso": "3.529.1",
-        "@aws-sdk/credential-provider-web-identity": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/credential-provider-imds": "^2.2.3",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.535.0",
+        "@aws-sdk/credential-provider-http": "3.535.0",
+        "@aws-sdk/credential-provider-ini": "3.549.0",
+        "@aws-sdk/credential-provider-process": "3.535.0",
+        "@aws-sdk/credential-provider-sso": "3.549.0",
+        "@aws-sdk/credential-provider-web-identity": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.535.0.tgz",
+      "integrity": "sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.549.0.tgz",
+      "integrity": "sha512-BGopRKHs7W8zkoH8qmSHrjudj263kXbhVkAUPxVUz0I28+CZNBgJC/RfVCbOpzmysIQEpwSqvOv1y0k+DQzIJQ==",
       "requires": {
-        "@aws-sdk/client-sso": "3.529.1",
-        "@aws-sdk/token-providers": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.549.0",
+        "@aws-sdk/token-providers": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.549.0.tgz",
+      "integrity": "sha512-QzclVXPxuwSI7515l34sdvliVq5leroO8P7RQFKRgfyQKO45o1psghierwG3PgV6jlMiv78FIAGJBr/n4qZ7YA==",
       "requires": {
-        "@aws-sdk/client-sts": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sts": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/lib-storage": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.549.0.tgz",
+      "integrity": "sha512-I4MBQQVPFLBNXmyX3bpwuSNxYxV3a4YXoulLpY7F39E7/EjF+AHPppBHJ4Z8pvoaTi/fSKtBc0EEEr5MN/gfZA==",
       "requires": {
-        "@smithy/abort-controller": "^2.1.3",
-        "@smithy/middleware-endpoint": "^2.4.4",
-        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/smithy-client": "^2.5.0",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.525.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.535.0.tgz",
+      "integrity": "sha512-7sijlfQsc4UO9Fsl11mU26Y5f9E7g6UoNg/iJUBpC5pgvvmdBRO5UEhbB/gnqvOEPsBXyhmfzbstebq23Qdz7A==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-arn-parser": "3.495.0",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-arn-parser": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.535.0.tgz",
+      "integrity": "sha512-hFKyqUBky0NWCVku8iZ9+PACehx0p6vuMw5YnZf8FVgHP0fode0b/NwQY6UY7oor/GftvRsAlRUAWGNFEGUpwA==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.535.0.tgz",
+      "integrity": "sha512-rBIzldY9jjRATxICDX7t77aW6ctqmVDgnuAOgbVT5xgHftt4o7PGWKoMvl/45hYqoQgxVFnCBof9bxkqSBebVA==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/is-array-buffer": "^2.1.1",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.535.0.tgz",
+      "integrity": "sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.535.0.tgz",
+      "integrity": "sha512-SxfS9wfidUZZ+WnlKRTCRn3h+XTsymXRXPJj8VV6hNRNeOwzNweoG3YhQbTowuuNfXf89m9v6meYkBBtkdacKw==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.535.0.tgz",
+      "integrity": "sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.535.0.tgz",
+      "integrity": "sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.525.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.535.0.tgz",
+      "integrity": "sha512-/dLG/E3af6ohxkQ5GBHT8tZfuPIg6eItKxCXuulvYj0Tqgf3Mb+xTsvSkxQsJF06RS4sH7Qsg/PnB8ZfrJrXpg==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-arn-parser": "3.495.0",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/signature-v4": "^2.1.3",
-        "@smithy/smithy-client": "^2.4.2",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-arn-parser": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.535.0.tgz",
+      "integrity": "sha512-Rb4sfus1Gc5paRl9JJgymJGsb/i3gJKK/rTuFZICdd1PBBE5osIOHP5CpzWYBtc5LlyZE1a2QoxPMCyG+QUGPw==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/signature-v4": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-middleware": "^2.1.3",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.523.0",
+      "version": "3.537.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.537.0.tgz",
+      "integrity": "sha512-2QWMrbwd5eBy5KCYn9a15JEWBgrK2qFEKQN2lqb/6z0bhtevIOxIRfC99tzvRuPt6nixFQ+ynKuBjcfT4ZFrdQ==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.525.0",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.540.0.tgz",
+      "integrity": "sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@aws-sdk/util-endpoints": "3.525.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@aws-sdk/util-endpoints": "3.540.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/region-config-resolver": {
-      "version": "3.525.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.535.0.tgz",
+      "integrity": "sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "@smithy/util-middleware": "^2.1.3",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.525.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.535.0.tgz",
+      "integrity": "sha512-tqCsEsEj8icW0SAh3NvyhRUq54Gz2pu4NM2tOSrFp7SO55heUUaRLSzYteNZCTOupH//AAaZvbN/UUTO/DrOog==",
       "requires": {
-        "@aws-sdk/middleware-sdk-s3": "3.525.0",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/protocol-http": "^3.2.1",
-        "@smithy/signature-v4": "^2.1.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-sdk-s3": "3.535.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.529.1",
+      "version": "3.549.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.549.0.tgz",
+      "integrity": "sha512-rJyeXkXknLukRFGuMQOgKnPBa+kLODJtOqEBf929SpQ96f1I6ytdndmWbB5B/OQN5Fu5DOOQUQqJypDQVl5ibQ==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.529.1",
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/property-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.3.3",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso-oidc": "3.549.0",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
       "requires": {
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.495.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.535.0.tgz",
+      "integrity": "sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.525.0",
+      "version": "3.540.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.540.0.tgz",
+      "integrity": "sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
-        "@smithy/util-endpoints": "^1.1.4",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -2189,21 +2366,25 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.535.0.tgz",
+      "integrity": "sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/types": "^2.10.1",
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.525.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.535.0.tgz",
+      "integrity": "sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==",
       "requires": {
-        "@aws-sdk/types": "3.523.0",
-        "@smithy/node-config-provider": "^2.2.4",
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.535.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/util-utf8-browser": {
@@ -2218,425 +2399,526 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.523.0",
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.535.0.tgz",
+      "integrity": "sha512-VXAq/Jz8KIrU84+HqsOJhIKZqG0PNTdi6n6PFQ4xJf44ZQHD/5C7ouH4qCFX5XgZXcgbRIcMVVYGC6Jye0dRng==",
       "requires": {
-        "@smithy/types": "^2.10.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/abort-controller": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/chunked-blob-reader": {
-      "version": "2.1.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.2.0.tgz",
+      "integrity": "sha512-3GJNvRwXBGdkDZZOGiziVYzDpn4j6zfyULHMDKAGIUo72yHALpE9CbhfQp/XcLNVoc1byfMpn6uW5H2BqPjgaQ==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/chunked-blob-reader-native": {
-      "version": "2.1.2",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.2.0.tgz",
+      "integrity": "sha512-VNB5+1oCgX3Fzs072yuRsUoC2N4Zg/LJ11DTxX3+Qu+Paa6AmbIF0E9sc2wthz9Psrk/zcOlTCyuposlIhPjZQ==",
       "requires": {
-        "@smithy/util-base64": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/config-resolver": {
-      "version": "2.1.5",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+      "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
       "requires": {
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-config-provider": "^2.2.1",
-        "@smithy/util-middleware": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/core": {
-      "version": "1.3.7",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==",
       "requires": {
-        "@smithy/middleware-endpoint": "^2.4.6",
-        "@smithy/middleware-retry": "^2.1.6",
-        "@smithy/middleware-serde": "^2.2.1",
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/smithy-client": "^2.4.4",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-middleware": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "2.2.6",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+      "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
       "requires": {
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/property-provider": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "@smithy/url-parser": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-codec": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-serde-browser": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.2.0.tgz",
+      "integrity": "sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==",
       "requires": {
-        "@smithy/eventstream-serde-universal": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-serde-config-resolver": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.2.0.tgz",
+      "integrity": "sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-serde-node": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
       "requires": {
-        "@smithy/eventstream-serde-universal": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-serde-universal": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
       "requires": {
-        "@smithy/eventstream-codec": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "2.4.4",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
       "requires": {
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/querystring-builder": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-base64": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/hash-blob-browser": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.2.0.tgz",
+      "integrity": "sha512-SGPoVH8mdXBqrkVCJ1Hd1X7vh1zDXojNN1yZyZTZsCno99hVue9+IYzWDjq/EQDDXxmITB0gBmuyPh8oAZSTcg==",
       "requires": {
-        "@smithy/chunked-blob-reader": "^2.1.1",
-        "@smithy/chunked-blob-reader-native": "^2.1.2",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/chunked-blob-reader": "^2.2.0",
+        "@smithy/chunked-blob-reader-native": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/hash-node": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+      "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/hash-stream-node": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.2.0.tgz",
+      "integrity": "sha512-aT+HCATOSRMGpPI7bi7NSsTNVZE/La9IaxLXWoVAYMxHT5hGO3ZOGEMZQg8A6nNL+pdFGtZQtND1eoY084HgHQ==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+      "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/is-array-buffer": {
-      "version": "2.1.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/md5-js": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.2.0.tgz",
+      "integrity": "sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+      "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
       "requires": {
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "2.4.6",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
       "requires": {
-        "@smithy/middleware-serde": "^2.2.1",
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/shared-ini-file-loader": "^2.3.5",
-        "@smithy/types": "^2.11.0",
-        "@smithy/url-parser": "^2.1.4",
-        "@smithy/util-middleware": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "2.1.6",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+      "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
       "requires": {
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/service-error-classification": "^2.1.4",
-        "@smithy/smithy-client": "^2.4.4",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-middleware": "^2.1.4",
-        "@smithy/util-retry": "^2.1.4",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "2.2.1",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-stack": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/node-config-provider": {
-      "version": "2.2.5",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
       "requires": {
-        "@smithy/property-provider": "^2.1.4",
-        "@smithy/shared-ini-file-loader": "^2.3.5",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "2.4.2",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
       "requires": {
-        "@smithy/abort-controller": "^2.1.4",
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/querystring-builder": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/property-provider": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/protocol-http": {
-      "version": "3.2.2",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-uri-escape": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "2.1.4",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+      "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
       "requires": {
-        "@smithy/types": "^2.11.0"
+        "@smithy/types": "^2.12.0"
       }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "2.3.5",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/signature-v4": {
-      "version": "2.1.4",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.2.1.tgz",
+      "integrity": "sha512-j5fHgL1iqKTsKJ1mTcw88p0RUcidDu95AWSeZTgiYJb+QcfwWU/UpBnaqiB59FNH5MiAZuSbOBnZlwzeeY2tIw==",
       "requires": {
-        "@smithy/eventstream-codec": "^2.1.4",
-        "@smithy/is-array-buffer": "^2.1.1",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "@smithy/util-middleware": "^2.1.4",
-        "@smithy/util-uri-escape": "^2.1.1",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/smithy-client": {
-      "version": "2.4.4",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
       "requires": {
-        "@smithy/middleware-endpoint": "^2.4.6",
-        "@smithy/middleware-stack": "^2.1.4",
-        "@smithy/protocol-http": "^3.2.2",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-stream": "^2.1.4",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/types": {
-      "version": "2.11.0",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/url-parser": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
       "requires": {
-        "@smithy/querystring-parser": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-base64": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
       "requires": {
-        "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-body-length-browser": {
-      "version": "2.1.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-body-length-node": {
-      "version": "2.2.1",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-buffer-from": {
-      "version": "2.1.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "requires": {
-        "@smithy/is-array-buffer": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-config-provider": {
-      "version": "2.2.1",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+      "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "2.1.6",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+      "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
       "requires": {
-        "@smithy/property-provider": "^2.1.4",
-        "@smithy/smithy-client": "^2.4.4",
-        "@smithy/types": "^2.11.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "2.2.6",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+      "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
       "requires": {
-        "@smithy/config-resolver": "^2.1.5",
-        "@smithy/credential-provider-imds": "^2.2.6",
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/property-provider": "^2.1.4",
-        "@smithy/smithy-client": "^2.4.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-endpoints": {
-      "version": "1.1.5",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
+      "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
       "requires": {
-        "@smithy/node-config-provider": "^2.2.5",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-hex-encoding": {
-      "version": "2.1.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-middleware": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
       "requires": {
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-retry": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+      "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
       "requires": {
-        "@smithy/service-error-classification": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-stream": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
       "requires": {
-        "@smithy/fetch-http-handler": "^2.4.4",
-        "@smithy/node-http-handler": "^2.4.2",
-        "@smithy/types": "^2.11.0",
-        "@smithy/util-base64": "^2.2.0",
-        "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "@smithy/util-utf8": "^2.2.0",
-        "tslib": "^2.5.0"
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-uri-escape": {
-      "version": "2.1.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-utf8": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "requires": {
-        "@smithy/util-buffer-from": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-waiter": {
-      "version": "2.1.4",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.2.0.tgz",
+      "integrity": "sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==",
       "requires": {
-        "@smithy/abort-controller": "^2.1.4",
-        "@smithy/types": "^2.11.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "@types/cron": {
@@ -2650,7 +2932,9 @@
       "version": "3.3.8"
     },
     "@types/node": {
-      "version": "20.11.25",
+      "version": "20.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.4.tgz",
+      "integrity": "sha512-E+Fa9z3wSQpzgYQdYmme5X3OTuejnnTx88A6p6vkkJosR3KBz+HpE3kqNm98VE6cfLFcISx7zW7MsJkH6KwbTw==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
@@ -2660,7 +2944,9 @@
       "version": "1.5.1"
     },
     "bowser": {
-      "version": "2.11.0"
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "buffer": {
       "version": "5.6.0",
@@ -2684,12 +2970,16 @@
     },
     "fast-xml-parser": {
       "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
         "strnum": "^1.0.5"
       }
     },
     "filesize": {
-      "version": "10.1.0"
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.1.tgz",
+      "integrity": "sha512-L0cdwZrKlwZQkMSFnCflJ6J2Y+5egO/p3vgRSDQGxQt++QbUZe5gMbRO6kg6gzwQDPvq2Fk9AmoxUNfZ5gdqaQ=="
     },
     "ieee754": {
       "version": "1.2.1"
@@ -2725,13 +3015,17 @@
       }
     },
     "strnum": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "tslib": {
       "version": "2.6.2"
     },
     "typescript": {
-      "version": "5.4.2",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
       "dev": true
     },
     "undici-types": {
@@ -2742,7 +3036,9 @@
       "version": "1.0.2"
     },
     "uuid": {
-      "version": "8.3.2"
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   "license": "MIT",
   "devDependencies": {
     "@types/cron": "^2.0.1",
-    "@types/node": "^20.11.25",
-    "typescript": "^5.4.2"
+    "@types/node": "^20.12.4",
+    "typescript": "^5.4.4"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.529.1",
-    "@aws-sdk/lib-storage": "^3.529.1",
+    "@aws-sdk/client-s3": "^3.549.0",
+    "@aws-sdk/lib-storage": "^3.549.0",
     "cron": "^3.1.6",
     "envsafe": "^2.0.3",
-    "filesize": "^10.1.0"
+    "filesize": "^10.1.1"
   },
   "keywords": []
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "A simple Node app to backup PostgreSQL databases to an S3 bucket",
   "main": "dist/index.js",
+  "type": "module",
   "scripts": {
     "start": "node dist/index.js",
     "build": "tsc"

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -6,7 +6,7 @@ import { filesize } from "filesize";
 import path from "path";
 import os from "os";
 
-import { env } from "./env";
+import { env } from "./env.js";
 
 const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
   console.log("Uploading backup to S3...");
@@ -20,6 +20,10 @@ const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
   if (env.AWS_S3_ENDPOINT) {
     console.log(`Using custom endpoint: ${env.AWS_S3_ENDPOINT}`)
     clientOptions['endpoint'] = env.AWS_S3_ENDPOINT;
+  }
+
+  if (env.BUCKET_SUBFOLDER) {
+    name = env.BUCKET_SUBFOLDER + "/" + name;
   }
 
   const client = new S3Client(clientOptions);

--- a/src/env.ts
+++ b/src/env.ts
@@ -29,6 +29,7 @@ export const env = envsafe({
   }),
   BUCKET_SUBFOLDER: str({
     desc: 'A subfolder to place the backup files in',
+    default: '',
     allowEmpty: true
   }),
   SINGLE_SHOT_MODE: bool({

--- a/src/env.ts
+++ b/src/env.ts
@@ -26,5 +26,14 @@ export const env = envsafe({
   BACKUP_FILE_PREFIX: str({
     desc: 'Prefix to the file name',
     default: 'backup',
+  }),
+  BUCKET_SUBFOLDER: str({
+    desc: 'A subfolder to place the backup files in',
+    allowEmpty: true
+  }),
+  SINGLE_SHOT_MODE: bool({
+    desc: 'Run a single backup on start and exit when completed',
+    default: false,
+    allowEmpty: true,
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { CronJob } from "cron";
-import { backup } from "./backup";
-import { env } from "./env";
+import { backup } from "./backup.js";
+import { env } from "./env.js";
 
 console.log("NodeJS Version: " + process.version);
 
@@ -12,15 +12,20 @@ const tryBackup = async () => {
   }
 }
 
+if (env.RUN_ON_STARTUP || env.SINGLE_SHOT_MODE) {
+  console.log("Running on start backup...");
+
+  await tryBackup();
+
+  if (env.SINGLE_SHOT_MODE) {
+    console.log("Database backup complete, exiting...");
+    process.exit(0);
+  }
+}
+
 const job = new CronJob(env.BACKUP_CRON_SCHEDULE, async () => {
   await tryBackup();
 });
-
-if (env.RUN_ON_STARTUP) {
-  console.log("Running on start backup...");
-
-  tryBackup();
-}
 
 job.start();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ const tryBackup = async () => {
     await backup();
   } catch (error) {
     console.error("Error while running backup: ", error);
+    process.exit(1);
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ES2020",
+    "module": "NodeNext",
     "outDir": "./dist",
     "esModuleInterop": true,
+    "moduleResolution": "NodeNext",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true


### PR DESCRIPTION
This PR adds two features -

- A single shot mode so that this template can be used with Railway's native cron scheduler, when `SINGLE_SHOT_MODE` is set to `true` the app will take a single backup on start and then exit right after.

- The ability to set a subfolder to place the backup files into with `BUCKET_SUBFOLDER`.