### PR TITLE
Add support for buckets with the object lock enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,29 @@
 A simple NodeJS application to backup your PostgreSQL database to S3 via a cron.
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/I4zGrH)
+
+## Configuration
+
+- `AWS_ACCESS_KEY_ID` - AWS access key ID.
+
+- `AWS_SECRET_ACCESS_KEY` - AWS secret access key, sometimes also called an application key.
+
+- `AWS_S3_BUCKET` - The name of the bucket that the access key ID and secret access key are authorized to access.
+
+- `AWS_S3_REGION` - The name of the region your bucket is located in, set to `auto` if unknown.
+
+- `BACKUP_DATABASE_URL` - The connection string of the database to backup.
+
+- `BACKUP_CRON_SCHEDULE` - The cron schedule to run the backup on. Example: `0 5 * * *`
+
+- `AWS_S3_ENDPOINT` - The S3 custom endpoint you want to use. Applicable for 3-rd party S3 services such as Cloudflare R2 or Backblaze R2.
+
+- `RUN_ON_STARTUP` - Run a backup on startup of this application then proceed with making backups on the set schedule.
+
+- `BACKUP_FILE_PREFIX` - Add a prefix to the file name.
+
+- `BUCKET_SUBFOLDER` - Define a subfolder to place the backup files in.
+
+- `SINGLE_SHOT_MODE` - Run a single backup on start and exit when completed. Useful with the platform's native CRON schedular.
+
+- `SUPPORT_OBJECT_LOCK` - Enables support for buckets with object lock by providing an MD5 hash with the backup file.

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,5 +1,5 @@
 import { exec, execSync } from "child_process";
-import { S3Client, S3ClientConfig } from "@aws-sdk/client-s3";
+import { S3Client, S3ClientConfig, PutObjectCommandInput } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { createReadStream, unlink, statSync } from "fs";
 import { filesize } from "filesize";
@@ -7,6 +7,7 @@ import path from "path";
 import os from "os";
 
 import { env } from "./env.js";
+import { createMD5 } from "./util.js";
 
 const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
   console.log("Uploading backup to S3...");
@@ -18,8 +19,25 @@ const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
   }
 
   if (env.AWS_S3_ENDPOINT) {
-    console.log(`Using custom endpoint: ${env.AWS_S3_ENDPOINT}`)
-    clientOptions['endpoint'] = env.AWS_S3_ENDPOINT;
+    console.log(`Using custom endpoint: ${env.AWS_S3_ENDPOINT}`);
+
+    clientOptions.endpoint = env.AWS_S3_ENDPOINT;
+  }
+
+  let params: PutObjectCommandInput = {
+    Bucket: bucket,
+    Key: name,
+    Body: createReadStream(path),
+  }
+
+  if (env.SUPPORT_OBJECT_LOCK) {
+    console.log("MD5 hashing file...");
+
+    const md5Hash = await createMD5(path);
+
+    console.log("Done hashing file");
+
+    params.ContentMD5 = Buffer.from(md5Hash, 'hex').toString('base64');
   }
 
   if (env.BUCKET_SUBFOLDER) {
@@ -30,11 +48,7 @@ const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
 
   await new Upload({
     client,
-    params: {
-      Bucket: bucket,
-      Key: name,
-      Body: createReadStream(path),
-    },
+    params: params
   }).done();
 
   console.log("Backup uploaded to S3...");

--- a/src/env.ts
+++ b/src/env.ts
@@ -36,5 +36,10 @@ export const env = envsafe({
     desc: 'Run a single backup on start and exit when completed',
     default: false,
     allowEmpty: true,
+  }),
+  // This is both time consuming and resource intensive so we leave it disabled by default
+  SUPPORT_OBJECT_LOCK: bool({
+    desc: 'Enables support for buckets with object lock by providing an MD5 hash with the backup file',
+    default: false
   })
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,10 @@
+import crypto from 'crypto';
+import fs from 'fs';
+
+export const createMD5 = (path: string) => new Promise<string>((resolve, reject) => {
+    const hash = crypto.createHash('md5')
+    const rs = fs.createReadStream(path)
+    rs.on('error', reject)
+    rs.on('data', chunk => hash.update(chunk))
+    rs.on('end', () => resolve(hash.digest('hex')))
+});


### PR DESCRIPTION
This feature was requested on Discord by a community member - https://discord.com/channels/713503345364697088/1248169251727216640

This PR adds a `SUPPORT_OBJECT_LOCK` environment variable that needs to be set to `true` since MD5 hashing a potentially large file isn't exactly free.

We have both tested and confirmed the upload works now with that variable.

This also adds a Configuration section in the readme file since there are quite a few environment variables now.