### PR TITLE
fix BUCKET_SUBFOLDER and add BACKUP_FILENAME

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,22 +1,26 @@
-import { exec, execSync } from "child_process";
-import { S3Client, S3ClientConfig, PutObjectCommandInput } from "@aws-sdk/client-s3";
+import {
+  PutObjectCommandInput,
+  S3Client,
+  S3ClientConfig,
+} from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
-import { createReadStream, unlink, statSync } from "fs";
+import { exec, execSync } from "child_process";
 import { filesize } from "filesize";
-import path from "path";
+import { createReadStream, statSync, unlink } from "fs";
 import os from "os";
+import path from "path";
 
 import { env } from "./env.js";
 import { createMD5 } from "./util.js";
 
-const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
+const uploadToS3 = async ({ name, path }: { name: string; path: string }) => {
   console.log("Uploading backup to S3...");
 
   const bucket = env.AWS_S3_BUCKET;
 
   const clientOptions: S3ClientConfig = {
-    region: env.AWS_S3_REGION
-  }
+    region: env.AWS_S3_REGION,
+  };
 
   if (env.AWS_S3_ENDPOINT) {
     console.log(`Using custom endpoint: ${env.AWS_S3_ENDPOINT}`);
@@ -24,11 +28,15 @@ const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
     clientOptions.endpoint = env.AWS_S3_ENDPOINT;
   }
 
+  if (env.BUCKET_SUBFOLDER) {
+    name = env.BUCKET_SUBFOLDER + "/" + name;
+  }
+
   let params: PutObjectCommandInput = {
     Bucket: bucket,
     Key: name,
     Body: createReadStream(path),
-  }
+  };
 
   if (env.SUPPORT_OBJECT_LOCK) {
     console.log("MD5 hashing file...");
@@ -37,59 +45,68 @@ const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
 
     console.log("Done hashing file");
 
-    params.ContentMD5 = Buffer.from(md5Hash, 'hex').toString('base64');
-  }
-
-  if (env.BUCKET_SUBFOLDER) {
-    name = env.BUCKET_SUBFOLDER + "/" + name;
+    params.ContentMD5 = Buffer.from(md5Hash, "hex").toString("base64");
   }
 
   const client = new S3Client(clientOptions);
 
   await new Upload({
     client,
-    params: params
+    params: params,
   }).done();
 
   console.log("Backup uploaded to S3...");
-}
+};
 
 const dumpToFile = async (filePath: string) => {
   console.log("Dumping DB to file...");
 
   await new Promise((resolve, reject) => {
-    exec(`pg_dump --dbname=${env.BACKUP_DATABASE_URL} --format=tar | gzip > ${filePath}`, (error, stdout, stderr) => {
-      if (error) {
-        reject({ error: error, stderr: stderr.trimEnd() });
-        return;
+    exec(
+      `pg_dump --dbname=${env.BACKUP_DATABASE_URL} --format=tar | gzip > ${filePath}`,
+      (error, stdout, stderr) => {
+        if (error) {
+          reject({ error: error, stderr: stderr.trimEnd() });
+          return;
+        }
+
+        // check if archive is valid and contains data
+        const isValidArchive =
+          execSync(`gzip -cd ${filePath} | head -c1`).length == 1
+            ? true
+            : false;
+        if (isValidArchive == false) {
+          reject({
+            error:
+              "Backup archive file is invalid or empty; check for errors above",
+          });
+          return;
+        }
+
+        // not all text in stderr will be a critical error, print the error / warning
+        if (stderr != "") {
+          console.log({ stderr: stderr.trimEnd() });
+        }
+
+        console.log("Backup archive file is valid");
+        console.log("Backup filesize:", filesize(statSync(filePath).size));
+
+        // if stderr contains text, let the user know that it was potently just a warning message
+        if (stderr != "") {
+          console.log(
+            `Potential warnings detected; Please ensure the backup file "${path.basename(
+              filePath
+            )}" contains all needed data`
+          );
+        }
+
+        resolve(undefined);
       }
-
-      // check if archive is valid and contains data
-      const isValidArchive = (execSync(`gzip -cd ${filePath} | head -c1`).length == 1) ? true : false;
-      if (isValidArchive == false) {
-        reject({ error: "Backup archive file is invalid or empty; check for errors above" });
-        return;
-      }
-
-      // not all text in stderr will be a critical error, print the error / warning
-      if (stderr != "") {
-        console.log({ stderr: stderr.trimEnd() });
-      }
-
-      console.log("Backup archive file is valid");
-      console.log("Backup filesize:", filesize(statSync(filePath).size));
-
-      // if stderr contains text, let the user know that it was potently just a warning message
-      if (stderr != "") {
-        console.log(`Potential warnings detected; Please ensure the backup file "${path.basename(filePath)}" contains all needed data`);
-      }
-
-      resolve(undefined);
-    });
+    );
   });
 
   console.log("DB dumped to file...");
-}
+};
 
 const deleteFile = async (path: string) => {
   console.log("Deleting file...");
@@ -100,13 +117,13 @@ const deleteFile = async (path: string) => {
     });
     resolve(undefined);
   });
-}
+};
 
 export const backup = async () => {
   console.log("Initiating DB backup...");
 
   const date = new Date().toISOString();
-  const timestamp = date.replace(/[:.]+/g, '-');
+  const timestamp = date.replace(/[:.]+/g, "-");
   const filename = `${env.BACKUP_FILE_PREFIX}-${timestamp}.tar.gz`;
   const filepath = path.join(os.tmpdir(), filename);
 
@@ -115,4 +132,4 @@ export const backup = async () => {
   await deleteFile(filepath);
 
   console.log("DB backup complete...");
-}
+};

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -124,7 +124,11 @@ export const backup = async () => {
 
   const date = new Date().toISOString();
   const timestamp = date.replace(/[:.]+/g, "-");
-  const filename = `${env.BACKUP_FILE_PREFIX}-${timestamp}.tar.gz`;
+  let partOfFilename = `${env.BACKUP_FILE_PREFIX}-${timestamp}`;
+  if (env.BACKUP_FILENAME) {
+    partOfFilename = env.BACKUP_FILENAME;
+  }
+  const filename = `${partOfFilename}.tar.gz`;
   const filepath = path.join(os.tmpdir(), filename);
 
   await dumpToFile(filepath);

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,4 @@
-import { envsafe, str, bool } from "envsafe";
+import { bool, envsafe, str } from "envsafe";
 
 export const env = envsafe({
   AWS_ACCESS_KEY_ID: str(),
@@ -6,40 +6,44 @@ export const env = envsafe({
   AWS_S3_BUCKET: str(),
   AWS_S3_REGION: str(),
   BACKUP_DATABASE_URL: str({
-    desc: 'The connection string of the database to backup.'
+    desc: "The connection string of the database to backup.",
   }),
   BACKUP_CRON_SCHEDULE: str({
-    desc: 'The cron schedule to run the backup on.',
-    default: '0 5 * * *',
-    allowEmpty: true
+    desc: "The cron schedule to run the backup on.",
+    default: "0 5 * * *",
+    allowEmpty: true,
   }),
   AWS_S3_ENDPOINT: str({
-    desc: 'The S3 custom endpoint you want to use.',
-    default: '',
+    desc: "The S3 custom endpoint you want to use.",
+    default: "",
     allowEmpty: true,
   }),
   RUN_ON_STARTUP: bool({
-    desc: 'Run a backup on startup of this application',
+    desc: "Run a backup on startup of this application",
     default: false,
     allowEmpty: true,
   }),
   BACKUP_FILE_PREFIX: str({
-    desc: 'Prefix to the file name',
-    default: 'backup',
+    desc: "Prefix to the file name",
+    default: "backup",
+  }),
+  BACKUP_FILENAME: str({
+    desc: "Your file name (this esclude BACKUP_FILE_PREFIX)",
+    default: "",
   }),
   BUCKET_SUBFOLDER: str({
-    desc: 'A subfolder to place the backup files in',
-    default: '',
-    allowEmpty: true
+    desc: "A subfolder to place the backup files in",
+    default: "",
+    allowEmpty: true,
   }),
   SINGLE_SHOT_MODE: bool({
-    desc: 'Run a single backup on start and exit when completed',
+    desc: "Run a single backup on start and exit when completed",
     default: false,
     allowEmpty: true,
   }),
   // This is both time consuming and resource intensive so we leave it disabled by default
   SUPPORT_OBJECT_LOCK: bool({
-    desc: 'Enables support for buckets with object lock by providing an MD5 hash with the backup file',
-    default: false
-  })
-})
+    desc: "Enables support for buckets with object lock by providing an MD5 hash with the backup file",
+    default: false,
+  }),
+});


### PR DESCRIPTION
Now when env BUCKET_SUBFOLDER is present, name change correctly before uploaded.
Now if you set env BACKUP_FILENAME you can rename the entire file name. Why? So you can overwrite the file with each new save without creating new ones. (This excludes BACKUP_FILE_PREFIX)