### PR TITLE
Support path style

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A simple NodeJS application to backup your PostgreSQL database to S3 via a cron.
 
 - `AWS_S3_ENDPOINT` - The S3 custom endpoint you want to use. Applicable for 3-rd party S3 services such as Cloudflare R2 or Backblaze R2.
 
+- `AWS_S3_FORCE_PATH_STYLE` - Use path style for the endpoint instead of the default subdomain style, useful for MinIO. Default `false`
+
 - `RUN_ON_STARTUP` - Run a backup on startup of this application then proceed with making backups on the set schedule.
 
 - `BACKUP_FILE_PREFIX` - Add a prefix to the file name.

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -15,7 +15,8 @@ const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
   const bucket = env.AWS_S3_BUCKET;
 
   const clientOptions: S3ClientConfig = {
-    region: env.AWS_S3_REGION
+    region: env.AWS_S3_REGION,
+    forcePathStyle: env.AWS_S3_FORCE_PATH_STYLE
   }
 
   if (env.AWS_S3_ENDPOINT) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -18,6 +18,11 @@ export const env = envsafe({
     default: '',
     allowEmpty: true,
   }),
+  AWS_S3_FORCE_PATH_STYLE: bool({
+    desc: 'Use path style for the endpoint instead of the default subdomain style, useful for MinIO',
+    default: false,
+    allowEmpty: true
+  }),
   RUN_ON_STARTUP: bool({
     desc: 'Run a backup on startup of this application',
     default: false,


### PR DESCRIPTION
Feature requested here - https://help.railway.app/templates/postgre-sql-s3-backups-3fd6f626

By default, the S3 client will use a subdomain for the bucket, but MinIO requires you to use a path as the bucket.