### PR TITLE
fix writing backup to bucket subfolder

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -25,6 +25,10 @@ const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
     clientOptions.endpoint = env.AWS_S3_ENDPOINT;
   }
 
+  if (env.BUCKET_SUBFOLDER) {
+    name = env.BUCKET_SUBFOLDER + "/" + name;
+  }
+
   let params: PutObjectCommandInput = {
     Bucket: bucket,
     Key: name,
@@ -39,10 +43,6 @@ const uploadToS3 = async ({ name, path }: { name: string, path: string }) => {
     console.log("Done hashing file");
 
     params.ContentMD5 = Buffer.from(md5Hash, 'hex').toString('base64');
-  }
-
-  if (env.BUCKET_SUBFOLDER) {
-    name = env.BUCKET_SUBFOLDER + "/" + name;
   }
 
   const client = new S3Client(clientOptions);


### PR DESCRIPTION
The BUCKET_SUBFOLDER functionality stopped working due to the name being updated after the params object was created.

I think the regression was introduced in this commit for reference: https://github.com/railwayapp-templates/postgres-s3-backups/commit/fedccf0c00421b9d636c9173f1415d8e579dd305

Let me know if you need anything else form me to get this merged in!