### PR TITLE
feat/backup-retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ A simple NodeJS application to backup your PostgreSQL database to S3 via a cron.
 - `SUPPORT_OBJECT_LOCK` - Enables support for buckets with object lock by providing an MD5 hash with the backup file.
 
 - `BACKUP_OPTIONS` - Add any valid pg_dump option, supported pg_dump options can be found [here](https://www.postgresql.org/docs/current/app-pgdump.html). Example: `--exclude-table=pattern`
+
+- `RETENTION_DAYS` - Number of days to retain backups. Older backups will be automatically deleted. If not set or set to 0, all backups will be retained.

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,55 +6,55 @@ export const env = envsafe({
   AWS_S3_BUCKET: str(),
   AWS_S3_REGION: str(),
   BACKUP_DATABASE_URL: str({
-    desc: "The connection string of the database to backup.",
+    desc: 'The connection string of the database to backup.'
   }),
   BACKUP_CRON_SCHEDULE: str({
-    desc: "The cron schedule to run the backup on.",
-    default: "0 5 * * *",
-    allowEmpty: true,
+    desc: 'The cron schedule to run the backup on.',
+    default: '0 5 * * *',
+    allowEmpty: true
   }),
   AWS_S3_ENDPOINT: str({
-    desc: "The S3 custom endpoint you want to use.",
-    default: "",
+    desc: 'The S3 custom endpoint you want to use.',
+    default: '',
     allowEmpty: true,
   }),
   AWS_S3_FORCE_PATH_STYLE: bool({
-    desc: "Use path style for the endpoint instead of the default subdomain style, useful for MinIO",
+    desc: 'Use path style for the endpoint instead of the default subdomain style, useful for MinIO',
     default: false,
-    allowEmpty: true,
+    allowEmpty: true
   }),
   RUN_ON_STARTUP: bool({
-    desc: "Run a backup on startup of this application",
+    desc: 'Run a backup on startup of this application',
     default: false,
     allowEmpty: true,
   }),
   BACKUP_FILE_PREFIX: str({
-    desc: "Prefix to the file name",
-    default: "backup",
+    desc: 'Prefix to the file name',
+    default: 'backup',
   }),
   BUCKET_SUBFOLDER: str({
-    desc: "A subfolder to place the backup files in",
-    default: "",
-    allowEmpty: true,
+    desc: 'A subfolder to place the backup files in',
+    default: '',
+    allowEmpty: true
   }),
   SINGLE_SHOT_MODE: bool({
-    desc: "Run a single backup on start and exit when completed",
+    desc: 'Run a single backup on start and exit when completed',
     default: false,
     allowEmpty: true,
   }),
   // This is both time consuming and resource intensive so we leave it disabled by default
   SUPPORT_OBJECT_LOCK: bool({
-    desc: "Enables support for buckets with object lock by providing an MD5 hash with the backup file",
-    default: false,
+    desc: 'Enables support for buckets with object lock by providing an MD5 hash with the backup file',
+    default: false
   }),
   BACKUP_OPTIONS: str({
-    desc: "Any valid pg_dump option.",
-    default: "",
+    desc: 'Any valid pg_dump option.',
+    default: '',
     allowEmpty: true,
   }),
   RETENTION_DAYS: num({
     desc: "Number of days to retain backups. If not set, cleanup is disabled.",
     default: undefined,
-    allowEmpty: true
+    allowEmpty: true,
   }),
-});
+})

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,4 @@
-import { envsafe, str, bool, num } from "envsafe";
+import { envsafe, str, bool, num } from 'envsafe';
 
 export const env = envsafe({
   AWS_ACCESS_KEY_ID: str(),
@@ -6,54 +6,54 @@ export const env = envsafe({
   AWS_S3_BUCKET: str(),
   AWS_S3_REGION: str(),
   BACKUP_DATABASE_URL: str({
-    desc: "The connection string of the database to backup.",
+    desc: 'The connection string of the database to backup.',
   }),
   BACKUP_CRON_SCHEDULE: str({
-    desc: "The cron schedule to run the backup on.",
-    default: "0 5 * * *",
+    desc: 'The cron schedule to run the backup on.',
+    default: '0 5 * * *',
     allowEmpty: true,
   }),
   AWS_S3_ENDPOINT: str({
-    desc: "The S3 custom endpoint you want to use.",
-    default: "",
+    desc: 'The S3 custom endpoint you want to use.',
+    default: '',
     allowEmpty: true,
   }),
   AWS_S3_FORCE_PATH_STYLE: bool({
-    desc: "Use path style for the endpoint instead of the default subdomain style, useful for MinIO",
+    desc: 'Use path style for the endpoint instead of the default subdomain style, useful for MinIO',
     default: false,
     allowEmpty: true,
   }),
   RUN_ON_STARTUP: bool({
-    desc: "Run a backup on startup of this application",
+    desc: 'Run a backup on startup of this application',
     default: false,
     allowEmpty: true,
   }),
   BACKUP_FILE_PREFIX: str({
-    desc: "Prefix to the file name",
-    default: "backup",
+    desc: 'Prefix to the file name',
+    default: 'backup',
   }),
   BUCKET_SUBFOLDER: str({
-    desc: "A subfolder to place the backup files in",
-    default: "",
+    desc: 'A subfolder to place the backup files in',
+    default: '',
     allowEmpty: true,
   }),
   SINGLE_SHOT_MODE: bool({
-    desc: "Run a single backup on start and exit when completed",
+    desc: 'Run a single backup on start and exit when completed',
     default: false,
     allowEmpty: true,
   }),
   // This is both time consuming and resource intensive so we leave it disabled by default
   SUPPORT_OBJECT_LOCK: bool({
-    desc: "Enables support for buckets with object lock by providing an MD5 hash with the backup file",
+    desc: 'Enables support for buckets with object lock by providing an MD5 hash with the backup file',
     default: false,
   }),
   BACKUP_OPTIONS: str({
-    desc: "Any valid pg_dump option.",
-    default: "",
+    desc: 'Any valid pg_dump option.',
+    default: '',
     allowEmpty: true,
   }),
   RETENTION_DAYS: num({
-    desc: "Number of days to retain backups. If not set, cleanup is disabled.",
+    desc: 'Number of days to retain backups. If not set, cleanup is disabled.',
     default: undefined,
     allowEmpty: true,
   }),

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,4 @@
-import { envsafe, str, bool } from "envsafe";
+import { envsafe, str, bool, num } from "envsafe";
 
 export const env = envsafe({
   AWS_ACCESS_KEY_ID: str(),
@@ -6,50 +6,55 @@ export const env = envsafe({
   AWS_S3_BUCKET: str(),
   AWS_S3_REGION: str(),
   BACKUP_DATABASE_URL: str({
-    desc: 'The connection string of the database to backup.'
+    desc: "The connection string of the database to backup.",
   }),
   BACKUP_CRON_SCHEDULE: str({
-    desc: 'The cron schedule to run the backup on.',
-    default: '0 5 * * *',
-    allowEmpty: true
+    desc: "The cron schedule to run the backup on.",
+    default: "0 5 * * *",
+    allowEmpty: true,
   }),
   AWS_S3_ENDPOINT: str({
-    desc: 'The S3 custom endpoint you want to use.',
-    default: '',
+    desc: "The S3 custom endpoint you want to use.",
+    default: "",
     allowEmpty: true,
   }),
   AWS_S3_FORCE_PATH_STYLE: bool({
-    desc: 'Use path style for the endpoint instead of the default subdomain style, useful for MinIO',
+    desc: "Use path style for the endpoint instead of the default subdomain style, useful for MinIO",
     default: false,
-    allowEmpty: true
+    allowEmpty: true,
   }),
   RUN_ON_STARTUP: bool({
-    desc: 'Run a backup on startup of this application',
+    desc: "Run a backup on startup of this application",
     default: false,
     allowEmpty: true,
   }),
   BACKUP_FILE_PREFIX: str({
-    desc: 'Prefix to the file name',
-    default: 'backup',
+    desc: "Prefix to the file name",
+    default: "backup",
   }),
   BUCKET_SUBFOLDER: str({
-    desc: 'A subfolder to place the backup files in',
-    default: '',
-    allowEmpty: true
+    desc: "A subfolder to place the backup files in",
+    default: "",
+    allowEmpty: true,
   }),
   SINGLE_SHOT_MODE: bool({
-    desc: 'Run a single backup on start and exit when completed',
+    desc: "Run a single backup on start and exit when completed",
     default: false,
     allowEmpty: true,
   }),
   // This is both time consuming and resource intensive so we leave it disabled by default
   SUPPORT_OBJECT_LOCK: bool({
-    desc: 'Enables support for buckets with object lock by providing an MD5 hash with the backup file',
-    default: false
+    desc: "Enables support for buckets with object lock by providing an MD5 hash with the backup file",
+    default: false,
   }),
   BACKUP_OPTIONS: str({
-    desc: 'Any valid pg_dump option.',
-    default: '',
+    desc: "Any valid pg_dump option.",
+    default: "",
     allowEmpty: true,
   }),
-})
+  RETENTION_DAYS: num({
+    desc: "Number of days to retain backups. If not set, cleanup is disabled.",
+    default: undefined,
+    allowEmpty: true,
+  }),
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,22 +11,22 @@ export const env = envsafe({
   BACKUP_CRON_SCHEDULE: str({
     desc: 'The cron schedule to run the backup on.',
     default: '0 5 * * *',
-    allowEmpty: true,
+    allowEmpty: true
   }),
   AWS_S3_ENDPOINT: str({
     desc: 'The S3 custom endpoint you want to use.',
     default: '',
-    allowEmpty: true,
+    allowEmpty: true
   }),
   AWS_S3_FORCE_PATH_STYLE: bool({
     desc: 'Use path style for the endpoint instead of the default subdomain style, useful for MinIO',
     default: false,
-    allowEmpty: true,
+    allowEmpty: true
   }),
   RUN_ON_STARTUP: bool({
     desc: 'Run a backup on startup of this application',
     default: false,
-    allowEmpty: true,
+    allowEmpty: true
   }),
   BACKUP_FILE_PREFIX: str({
     desc: 'Prefix to the file name',
@@ -35,26 +35,26 @@ export const env = envsafe({
   BUCKET_SUBFOLDER: str({
     desc: 'A subfolder to place the backup files in',
     default: '',
-    allowEmpty: true,
+    allowEmpty: true
   }),
   SINGLE_SHOT_MODE: bool({
     desc: 'Run a single backup on start and exit when completed',
     default: false,
-    allowEmpty: true,
+    allowEmpty: true
   }),
   // This is both time consuming and resource intensive so we leave it disabled by default
   SUPPORT_OBJECT_LOCK: bool({
     desc: 'Enables support for buckets with object lock by providing an MD5 hash with the backup file',
-    default: false,
+    default: false
   }),
   BACKUP_OPTIONS: str({
     desc: 'Any valid pg_dump option.',
     default: '',
-    allowEmpty: true,
+    allowEmpty: true
   }),
   RETENTION_DAYS: num({
     desc: 'Number of days to retain backups. If not set, cleanup is disabled.',
     default: undefined,
-    allowEmpty: true,
+    allowEmpty: true
   }),
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,4 @@
-import { envsafe, str, bool, num } from 'envsafe';
+import { envsafe, str, bool, num } from "envsafe";
 
 export const env = envsafe({
   AWS_ACCESS_KEY_ID: str(),
@@ -6,54 +6,54 @@ export const env = envsafe({
   AWS_S3_BUCKET: str(),
   AWS_S3_REGION: str(),
   BACKUP_DATABASE_URL: str({
-    desc: 'The connection string of the database to backup.',
+    desc: "The connection string of the database to backup.",
   }),
   BACKUP_CRON_SCHEDULE: str({
-    desc: 'The cron schedule to run the backup on.',
-    default: '0 5 * * *',
-    allowEmpty: true
+    desc: "The cron schedule to run the backup on.",
+    default: "0 5 * * *",
+    allowEmpty: true,
   }),
   AWS_S3_ENDPOINT: str({
-    desc: 'The S3 custom endpoint you want to use.',
-    default: '',
-    allowEmpty: true
+    desc: "The S3 custom endpoint you want to use.",
+    default: "",
+    allowEmpty: true,
   }),
   AWS_S3_FORCE_PATH_STYLE: bool({
-    desc: 'Use path style for the endpoint instead of the default subdomain style, useful for MinIO',
+    desc: "Use path style for the endpoint instead of the default subdomain style, useful for MinIO",
     default: false,
-    allowEmpty: true
+    allowEmpty: true,
   }),
   RUN_ON_STARTUP: bool({
-    desc: 'Run a backup on startup of this application',
+    desc: "Run a backup on startup of this application",
     default: false,
-    allowEmpty: true
+    allowEmpty: true,
   }),
   BACKUP_FILE_PREFIX: str({
-    desc: 'Prefix to the file name',
-    default: 'backup',
+    desc: "Prefix to the file name",
+    default: "backup",
   }),
   BUCKET_SUBFOLDER: str({
-    desc: 'A subfolder to place the backup files in',
-    default: '',
-    allowEmpty: true
+    desc: "A subfolder to place the backup files in",
+    default: "",
+    allowEmpty: true,
   }),
   SINGLE_SHOT_MODE: bool({
-    desc: 'Run a single backup on start and exit when completed',
+    desc: "Run a single backup on start and exit when completed",
     default: false,
-    allowEmpty: true
+    allowEmpty: true,
   }),
   // This is both time consuming and resource intensive so we leave it disabled by default
   SUPPORT_OBJECT_LOCK: bool({
-    desc: 'Enables support for buckets with object lock by providing an MD5 hash with the backup file',
-    default: false
+    desc: "Enables support for buckets with object lock by providing an MD5 hash with the backup file",
+    default: false,
   }),
   BACKUP_OPTIONS: str({
-    desc: 'Any valid pg_dump option.',
-    default: '',
-    allowEmpty: true
+    desc: "Any valid pg_dump option.",
+    default: "",
+    allowEmpty: true,
   }),
   RETENTION_DAYS: num({
-    desc: 'Number of days to retain backups. If not set, cleanup is disabled.',
+    desc: "Number of days to retain backups. If not set, cleanup is disabled.",
     default: undefined,
     allowEmpty: true
   }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { CronJob } from "cron";
 import { backup } from "./backup.js";
 import { env } from "./env.js";
+import { applyRetentionPolicy } from "./retention.js";
 
 console.log("NodeJS Version: " + process.version);
 
@@ -9,6 +10,15 @@ const tryBackup = async () => {
     await backup();
   } catch (error) {
     console.error("Error while running backup: ", error);
+    process.exit(1);
+  }
+}
+
+const tryRetention = async () => {
+  try {
+    await applyRetentionPolicy();
+  } catch (error) {
+    console.error("Error while running retention policy: ", error);
     process.exit(1);
   }
 }
@@ -31,3 +41,14 @@ const job = new CronJob(env.BACKUP_CRON_SCHEDULE, async () => {
 job.start();
 
 console.log("Backup cron scheduled...");
+
+// Add daily retention policy job only if RETENTION_DAYS is set
+if (env.RETENTION_DAYS && env.RETENTION_DAYS > 0) {
+  const retentionJob = new CronJob("0 0 * * *", async () => {
+    await tryRetention();
+  });
+  retentionJob.start();
+  console.log("Retention cron scheduled...");
+} else {
+  console.log("Retention policy not configured. Skipping daily retention job.");
+}

--- a/src/retention.ts
+++ b/src/retention.ts
@@ -1,0 +1,101 @@
+import {
+  S3Client,
+  S3ClientConfig,
+  ListObjectsV2Command,
+  DeleteObjectsCommand,
+} from "@aws-sdk/client-s3";
+import { env } from "./env.js";
+
+export const applyRetentionPolicy = async () => {
+  if (env.RETENTION_DAYS <= 0) {
+    console.log("Backup retention policy not set or disabled.");
+    return;
+  }
+
+  console.log(
+    `Applying retention policy: keeping backups for ${env.RETENTION_DAYS} days...`
+  );
+  const bucket = env.AWS_S3_BUCKET;
+  const clientOptions: S3ClientConfig = {
+    region: env.AWS_S3_REGION,
+    forcePathStyle: env.AWS_S3_FORCE_PATH_STYLE,
+  };
+  if (env.AWS_S3_ENDPOINT) {
+    clientOptions.endpoint = env.AWS_S3_ENDPOINT;
+  }
+
+  const client = new S3Client(clientOptions);
+  const prefix = env.BUCKET_SUBFOLDER ? `${env.BUCKET_SUBFOLDER}/` : "";
+  const retentionDate = new Date();
+  retentionDate.setDate(retentionDate.getDate() - env.RETENTION_DAYS);
+
+  const listParams = {
+    Bucket: bucket,
+    Prefix: prefix,
+  };
+
+  try {
+    let objectsToDelete: { Key: string }[] = [];
+    let isTruncated = true;
+    let continuationToken: string | undefined;
+
+    while (isTruncated) {
+      const listCommand = new ListObjectsV2Command({
+        ...listParams,
+        ContinuationToken: continuationToken,
+      });
+      const data = await client.send(listCommand);
+
+      if (data.Contents) {
+        const expiredObjects = data.Contents.filter(
+          (object) =>
+            object.LastModified &&
+            object.LastModified < retentionDate &&
+            object.Key
+        ).map((object) => ({ Key: object.Key! }));
+
+        objectsToDelete.push(...expiredObjects);
+      }
+
+      isTruncated = !!data.IsTruncated;
+      continuationToken = data.NextContinuationToken;
+
+      // If we've accumulated 1000 objects or more, delete them in a batch
+      if (objectsToDelete.length >= 1000) {
+        await deleteExpiredObjects(client, bucket, objectsToDelete);
+        objectsToDelete = [];
+      }
+    }
+
+    // Delete any remaining objects
+    if (objectsToDelete.length > 0) {
+      await deleteExpiredObjects(client, bucket, objectsToDelete);
+    }
+  } catch (error) {
+    console.error("Error while applying retention policy:", error);
+  }
+
+  console.log("Retention policy applied successfully.");
+};
+
+async function deleteExpiredObjects(
+  client: S3Client,
+  bucket: string,
+  objects: { Key: string }[]
+) {
+  const deleteParams = {
+    Bucket: bucket,
+    Delete: { Objects: objects },
+  };
+
+  try {
+    const deleteCommand = new DeleteObjectsCommand(deleteParams);
+    const deleteResult = await client.send(deleteCommand);
+    console.log(`Deleted ${deleteResult.Deleted?.length} expired backups.`);
+    if (deleteResult.Errors && deleteResult.Errors.length > 0) {
+      console.error("Some objects could not be deleted:", deleteResult.Errors);
+    }
+  } catch (error) {
+    console.error("Error deleting expired objects:", error);
+  }
+}


### PR DESCRIPTION
# Add Configurable Retention Policy for Database Backups

## Changes
- Implement a configurable retention policy for database backups
- Add new environment variable `RETENTION_DAYS` to control backup retention period
- Create a daily job to apply the retention policy
- Update README with new configuration option and explanation

## Details
This PR introduces a retention policy feature for our database backup system. It allows users to automatically manage the lifecycle of their backups by specifying how long backups should be kept.

### New Environment Variable
- `RETENTION_DAYS`: Number of days to retain backups. Backups older than this will be automatically deleted.
  - If not set or set to 0, all backups will be retained indefinitely.

### Implementation
- A new daily job runs at midnight to apply the retention policy.
- The job checks the creation date of each backup in the S3 bucket.
- Backups older than the specified retention period are deleted.

### Documentation
- The README has been updated to include information about the new `RETENTION_DAYS` configuration option.
- A new section explaining how the retention policy works has been added to the documentation.

## Testing
- Tested with various `RETENTION_DAYS` values to ensure correct behavior.
- Verified that backups older than the retention period are properly deleted.
- Confirmed that setting `RETENTION_DAYS` to 0 or leaving it unset retains all backups.

## Notes
- This change is backwards compatible. Existing setups without `RETENTION_DAYS` specified will continue to retain all backups.
- Users should be advised to set an appropriate retention period based on their backup strategy and storage constraints.