### PR TITLE
Make Node version adjustable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:20.11.1-alpine AS build
+ARG NODE_VERSION='20.11.1'
+
+FROM node:${NODE_VERSION}-alpine AS build
 
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 ENV NPM_CONFIG_FUND=false
@@ -12,7 +14,7 @@ RUN npm ci && \
     npm run build && \
     npm prune --production
 
-FROM node:20.11.1-alpine
+FROM node:${NODE_VERSION}-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
To make this template compatible for Postgresql v17 backups the Node version should be configurable as well.
If one would set `NODE_VERSION=22` and `PG_VERSION=17` it will backup v17 databases.