### PR TITLE
Add Postgres 17 notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ A simple NodeJS application to backup your PostgreSQL database to S3 via a cron.
 - `SUPPORT_OBJECT_LOCK` - Enables support for buckets with object lock by providing an MD5 hash with the backup file.
 
 - `BACKUP_OPTIONS` - Add any valid pg_dump option, supported pg_dump options can be found [here](https://www.postgresql.org/docs/current/app-pgdump.html). Example: `--exclude-table=pattern`
+
+- `NODE_VERSION` - Specify a custom Node.js version to override the default version set in the Dockerfile.
+
+- `PG_VERSION` - Specify a custom PostgreSQL version to override the default version set in the Dockerfile.
+
+## Notes for Postgres 17
+
+If backing up a Postgres 17 database imported from Postgres 16, set `PG_VERSION=17` and `NODE_VERSION=22`.


### PR DESCRIPTION
# Changelog

Update README with the changes made on #32 . 

- Add env variables `NODE_VERSION` and `PG_VERSION` description;
- Add `Notes for Postgres 17`  explaining how to handle a scenario where the current database is a Postgres 17that has imported a dump from a Postgres 16. 